### PR TITLE
Add Zod schema validation for Converter interface

### DIFF
--- a/src/schemas/converter.ts
+++ b/src/schemas/converter.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+const OptionSchema = z.object({
+  description: z.string(),
+  required: z.boolean(),
+  default: z.any().optional(),
+});
+
+export const ConverterSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  sourceFormats: z.array(z.string()),
+  targetFormats: z.array(z.string()),
+  convert: z
+    .function()
+    .args(z.string(), z.string(), z.record(z.string(), z.any().optional()))
+    .returns(z.promise(z.boolean())),
+  getOptions: z
+    .function()
+    .args()
+    .returns(z.record(z.string(), OptionSchema))
+    .optional(),
+});
+
+export type Converter = z.infer<typeof ConverterSchema>;


### PR DESCRIPTION
## Description
This PR adds a Zod schema implementation for the Converter interface, providing runtime validation capabilities and type safety. The implementation exports both the schema for validation and a TypeScript type derived from the schema.

## Changes

- Created `ConverterSchema` for validating objects against the Converter interface
- Added `OptionSchema` to validate the structure returned by `getOptions`
- Exported a TypeScript type `Converter` inferred from the schema
